### PR TITLE
Add a Dockerfile to build solution as container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:alpine AS builder
+
+WORKDIR /src
+
+RUN apk add --no-cache git  \
+                       build-base \
+                       python
+RUN git clone https://github.com/calxibe/StorjMonitor.git
+
+WORKDIR /src/StorjMonitor
+
+RUN rm -rf node_modules
+RUN npm install
+RUN chmod +x storjMonitor.sh
+
+FROM node:alpine
+
+ENV TOKEN 1234
+ENV STORJ_DAEMON storj
+ENV STORJ_PORT 45015
+
+RUN apk add --no-cache python
+WORKDIR /src
+COPY --from=builder /src/StorjMonitor .
+
+ENTRYPOINT sed -i "s/YOUR-TOKEN-HERE/${TOKEN}/" storjMonitor.js && \
+           sed -i "s/127\.0\.0\.1/${STORJ_DAEMON}/" storjMonitor.js && \
+           sed -i "s/45015/${STORJ_PORT}/" storjMonitor.js && \
+           ./storjMonitor.sh

--- a/README.md
+++ b/README.md
@@ -17,6 +17,22 @@ The monitor can easily be started by running "storjMonitor.bat", by download the
 5. Enter your API Key from the website into the line 10 in storjMonitor.js (var token = "YOUR-TOKEN-HERE").
 6. Execute the Monitor Script. `./storjMonitor.sh` or via seperate screen `screen -dmS StorjMonitor ./storjMonitor.sh`
 
+## Docker
+
+1. Pull the Docker image from docker hub. `docker pull calxibe/StorjMonitor`
+2. Run the Docker container.`docker run -e TOKEN=MY-TOKEN -e STORJ_DAEMON=1.2.3.4 --name StorjMonitor calxibe/StorjMonitor`
+   * 3 variables exists:
+     * `TOKEN`: the API key from the website
+     * `STORJ_DAEMON`: the host of Storj daemon (`storj` per default)
+     * `STORJ_PORT`: the port of Storj daemon (`45015` per default)
+
+If Storj daemon is running also on a docker, the simplest is to make a link at
+run time. (let's say that the container of Storj Daemon is `MyStorjContainer`):
+
+```
+docker run -e TOKEN=MY-TOKEN --link MyStorjContainer:storj --name StorjMonitor calxibe/StorjMonitor:latest
+```
+
 ## Troubleshooting
 
 In case the Linux Install Script is throwing issues you may need to install some dependencies first:

--- a/storjMonitor.js
+++ b/storjMonitor.js
@@ -5,9 +5,11 @@
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0
 const dnode = require('dnode');
 const http = require('http');
-const requestify = require('requestify'); 
+const requestify = require('requestify');
 
 var token = "YOUR-TOKEN-HERE"; //api token can be create under "Nodes" -> "API-Key"
+var daemon_host= "127.0.0.1"; //where the storj daemon is running
+var daemon_port= 45015; //on which port storj daemon is listening
 var log = console.log;
 
 console.log = function () {
@@ -26,7 +28,7 @@ console.log = function () {
 };
 
 function fParseNodes() {
-	const daemon = dnode.connect(45015);
+	const daemon = dnode.connect(daemon_host, daemon_port);
 
 	daemon.on('remote', (rpc) => {
 		rpc.status(function(err, shares) {
@@ -42,7 +44,7 @@ function fParseNodes() {
 	}).on('error',function(err){
 		console.log('Error connecting to StorjShare Client, are you sure its running?');
 		console.log(err);
-	});		
+	});
 }
 
 function fSubmitData(nodeId,meta) {


### PR DESCRIPTION
In order to have everything fully working, `calxibe` should have also an automated build into `hub.docker.com` for `calxibe/StorjMonitor` and that should be it!