### PR TITLE
Use system sleep instead node setInterval

### DIFF
--- a/storjMonitor.js
+++ b/storjMonitor.js
@@ -28,38 +28,37 @@ console.log = function () {
 };
 
 function fParseNodes() {
-	const daemon = dnode.connect(daemon_host, daemon_port);
+  const daemon = dnode.connect(daemon_host, daemon_port);
 
-	daemon.on('remote', (rpc) => {
-		rpc.status(function(err, shares) {
-			daemon.end();
-			shares.forEach((share) => {
-				console.log(share.id + ' | Submit to Storjstat');
-				fSubmitData(share.id, share.meta);
-			});
-		});
-	}).on('fail',function(err){
-		console.log('Error in protocol layer, try restaring StorjMonitor...');
-		console.log(err);
-	}).on('error',function(err){
-		console.log('Error connecting to StorjShare Client, are you sure its running?');
-		console.log(err);
-	});
+  daemon.on('remote', (rpc) => {
+    rpc.status(function(err, shares) {
+      daemon.end();
+      shares.forEach((share) => {
+        console.log(share.id + ' | Submit to Storjstat');
+        fSubmitData(share.id, share.meta);
+      });
+    });
+  }).on('fail',function(err){
+    console.log('Error in protocol layer, try restaring StorjMonitor...');
+    console.log(err);
+  }).on('error',function(err){
+    console.log('Error connecting to StorjShare Client, are you sure its running?');
+    console.log(err);
+  });
 }
 
 function fSubmitData(nodeId,meta) {
-	requestify.post('https://storjstat.com:3000/clientnode?token=' + token + '&nodeID=' + nodeId, meta)
-		.then(function(response) {
-			var obj = response.getBody();
-			if (obj.saved == true) {
-				console.log(nodeId + ' | Success');
-			} else {
-				console.log(nodeId + ' | Error');
-			}
-		}).fail(function(response) {
-			console.log('ERROR ' + JSON.stringify(response.getBody()));
-		});
+  requestify.post('https://storjstat.com:3000/clientnode?token=' + token + '&nodeID=' + nodeId, meta)
+    .then(function(response) {
+      var obj = response.getBody();
+      if (obj.saved == true) {
+        console.log(nodeId + ' | Success');
+      } else {
+        console.log(nodeId + ' | Error');
+      }
+    }).fail(function(response) {
+      console.log('ERROR ' + JSON.stringify(response.getBody()));
+    });
 }
 
-setInterval(function(){ fParseNodes(); }, 900000);
 fParseNodes();

--- a/storjMonitor.sh
+++ b/storjMonitor.sh
@@ -1,1 +1,1 @@
-node storjMonitor.js
+while true; do node storjMonitor.js; sleep 900; done


### PR DESCRIPTION
storjMonitor.js occupy 101m of RAM while doing nothing between Storj node polls.

This PR removes nodejs setInterval in favor of the system while loop. Which means storjMonitor is running once in 15 mins and don't work in the meantime.